### PR TITLE
Add MatcherApp desktop matcher project

### DIFF
--- a/matcher_app/README.md
+++ b/matcher_app/README.md
@@ -1,0 +1,105 @@
+# MatcherApp
+
+MatcherApp — настільна програма для локальної звірки товарних прайсів між «моїм» прайсом та прайсами постачальників. Застосунок працює офлайн, підтримує нормалізацію брендів/моделей/типів плівок, strict та fuzzy матчинг з блокуванням, а також експорт результатів у CSV.
+
+## Можливості
+
+- Імпорт CSV/XLSX файлів мого прайсу та декількох прайсів постачальників.
+- Автоматичне визначення колонок з можливістю ручного мапінгу.
+- Нормалізація текстових полів, побудова blocking-ключів.
+- Комбінований strict та fuzzy матчинг з конфігурованими вагами та порогами.
+- Класифікація рядків на Exact / Near / Unmatched, генерація `canon_id` (опційно).
+- Експорт результатів у CSV (utf-8-sig).
+- Логування у файл `matcher.log` з ротацією.
+
+## Вимоги
+
+- Python 3.11
+- Windows 10/11 (рекомендовано для GUI та збірки `.exe`).
+
+## Встановлення
+
+```bat
+python -m venv .venv
+.venv\Scripts\activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+## Запуск із вихідного коду
+
+```bat
+.venv\Scripts\activate
+python main.py
+```
+
+Або скористайтесь скриптом:
+
+```bat
+run.bat
+```
+
+## Збірка виконуваного файлу
+
+```bat
+.venv\Scripts\activate
+pyinstaller --noconfirm --clean --onefile --windowed --name "MatcherApp" --icon icon.ico main.py
+```
+
+Або:
+
+```bat
+build.bat
+```
+
+Готовий `MatcherApp.exe` з'явиться в каталозі `dist`.
+
+## Приклад даних
+
+### «Мій прайс» (CSV)
+
+| Назва позиції           | Виробник | Модель         | Тип плівки   | Артикул | Ціна |
+|-------------------------|----------|----------------|--------------|---------|------|
+| Захисна плівка iPhone   | Apple    | iPhone 13      | матова       | A13-MAT | 299  |
+| Захисна плівка Samsung  | Samsung  | Galaxy S22     | прозора      | S22-CLR | 249  |
+| Захисна плівка Redmi    | Xiaomi   | Redmi Note 11  | anti blue    | RN11-AB | 189  |
+
+### Прайс постачальника (XLSX)
+
+| Наименование           | Производитель | Device Model  | Series        | SKU      | Price |
+|------------------------|----------------|---------------|---------------|----------|-------|
+| Film iPhone 13 Matte   | Apple          | iPhone 13     | matte         | APP-13-M | 305   |
+| Film Galaxy S22 Clear  | Samsung        | Galaxy S22    | clear         | SAM-S22C | 250   |
+| Film Redmi Note 11 AB  | Xiaomi         | Redmi Note 11 | anti-blue     | XM-RN11A | 195   |
+
+Ці приклади демонструють різні назви колонок (українська/російська/англійська), що дозволяє перевірити автоматичне визначення та ручне мапування.
+
+## Структура проєкту
+
+```
+matcher_app/
+  main.py
+  run.bat
+  build.bat
+  icon.ico
+  matcher/
+    __init__.py
+    config.py
+    core.py
+    exporters.py
+    hashid.py
+    io_utils.py
+    logging_utils.py
+    matching.py
+    models.py
+    normalization.py
+    ui_app.py
+```
+
+## Конфігурація
+
+Після першого запуску поруч із `main.py` буде створено `config.json`, де зберігаються користувацькі мапінги колонок і, за потреби, оновлені пороги/ваги.
+
+## Ліцензія
+
+Проєкт призначений як MVP і може модифікуватися відповідно до внутрішніх потреб команди.

--- a/matcher_app/build.bat
+++ b/matcher_app/build.bat
@@ -1,0 +1,9 @@
+@echo off
+SETLOCAL
+IF NOT EXIST .venv (
+    echo Створіть середовище .venv перед збіркою.
+    exit /b 1
+)
+CALL .venv\Scripts\activate.bat
+pyinstaller --noconfirm --clean --onefile --windowed --name "MatcherApp" --icon icon.ico main.py
+ENDLOCAL

--- a/matcher_app/main.py
+++ b/matcher_app/main.py
@@ -1,0 +1,13 @@
+"""Точка входу MatcherApp."""
+from __future__ import annotations
+
+from matcher.ui_app import MatcherAppUI
+
+
+def main() -> None:
+    app = MatcherAppUI()
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/matcher_app/matcher/__init__.py
+++ b/matcher_app/matcher/__init__.py
@@ -1,0 +1,6 @@
+"""Пакет MatcherApp."""
+
+from .config import Config, load_config, save_config
+from .core import MatcherCore
+
+__all__ = ["Config", "load_config", "save_config", "MatcherCore"]

--- a/matcher_app/matcher/config.py
+++ b/matcher_app/matcher/config.py
@@ -1,0 +1,95 @@
+"""Конфігурація застосунку MatcherApp."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+import json
+
+CONFIG_FILE_NAME = "config.json"
+
+
+@dataclass
+class Config:
+    """Структура конфігурації matcher-ядра."""
+
+    exact_threshold: int = 85
+    near_threshold: int = 70
+    weights: Dict[str, int] = field(
+        default_factory=lambda: {
+            "brand_exact": 40,
+            "model_fuzzy": 35,
+            "film_exact": 15,
+            "name_fuzzy": 5,
+            "price_proximity": 5,
+        }
+    )
+    price_delta: float = 0.10
+    film_map: Dict[str, str] = field(
+        default_factory=lambda: {
+            "матова": "матова",
+            "matte": "матова",
+            "anti glare": "матова",
+            "anti-glare": "матова",
+            "прозора": "прозора",
+            "clear": "прозора",
+            "privacy matte": "privacy matte",
+            "privacy mate": "privacy mate",
+            "privacy clear": "privacy clear",
+            "anti blue": "anti-blue",
+            "anti-blue": "anti-blue",
+        }
+    )
+    last_mappings: Dict[str, Dict[str, str]] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Config":
+        """Створює конфігурацію з dict, насичуючи дефолтні значення."""
+        cfg = cls()
+        cfg.exact_threshold = int(data.get("exact_threshold", cfg.exact_threshold))
+        cfg.near_threshold = int(data.get("near_threshold", cfg.near_threshold))
+        cfg.price_delta = float(data.get("price_delta", cfg.price_delta))
+        cfg.weights.update(data.get("weights", {}))
+        cfg.film_map.update({k.lower(): v for k, v in data.get("film_map", {}).items()})
+        cfg.last_mappings.update(data.get("last_mappings", {}))
+        return cfg
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Серіалізує конфігурацію у dict."""
+        return {
+            "exact_threshold": self.exact_threshold,
+            "near_threshold": self.near_threshold,
+            "price_delta": self.price_delta,
+            "weights": self.weights,
+            "film_map": self.film_map,
+            "last_mappings": self.last_mappings,
+        }
+
+
+def get_config_path(base_dir: Optional[Path] = None) -> Path:
+    """Повертає шлях до файлу конфігурації біля exe/скрипту."""
+    if base_dir is None:
+        base_dir = Path.cwd()
+    return base_dir / CONFIG_FILE_NAME
+
+
+def load_config(base_dir: Optional[Path] = None) -> Config:
+    """Завантажує конфігурацію з JSON, якщо файл існує."""
+    cfg = Config()
+    cfg_path = get_config_path(base_dir)
+    if cfg_path.exists():
+        try:
+            data = json.loads(cfg_path.read_text(encoding="utf-8"))
+            cfg = Config.from_dict(data)
+        except (json.JSONDecodeError, OSError) as exc:
+            raise RuntimeError(f"Не вдалося прочитати конфіг: {exc}") from exc
+    return cfg
+
+
+def save_config(cfg: Config, base_dir: Optional[Path] = None) -> None:
+    """Зберігає конфігурацію у JSON."""
+    cfg_path = get_config_path(base_dir)
+    try:
+        cfg_path.write_text(json.dumps(cfg.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"Не вдалося зберегти конфіг: {exc}") from exc

--- a/matcher_app/matcher/core.py
+++ b/matcher_app/matcher/core.py
@@ -1,0 +1,118 @@
+"""Бізнес-логіка MatcherApp."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+from . import config as config_module
+from .hashid import hashid
+from .io_utils import apply_mapping, detect_columns, read_table
+from .matching import match_user_vs_suppliers
+from .models import ColumnMapping, SupplierData
+from .normalization import normalize_dataframe
+
+
+class MatcherCore:
+    """Диригент бізнес-логіки: імпорт, нормалізація, матчинг."""
+
+    def __init__(self, base_dir: Optional[Path] = None) -> None:
+        self.base_dir = Path(base_dir or Path.cwd())
+        self.config = config_module.load_config(self.base_dir)
+        self.logger = None
+        self.user_df: Optional[pd.DataFrame] = None
+        self.user_path: Optional[Path] = None
+        self.suppliers: List[SupplierData] = []
+        self.results: Dict[str, pd.DataFrame] | None = None
+
+    def attach_logger(self, logger) -> None:
+        """Присвоює створений logger (для ін'єкції з UI)."""
+        self.logger = logger
+
+    # --- Конфіг та мапінг ---
+    def load_dataframe(self, path: Path) -> pd.DataFrame:
+        """Зчитує таблицю у DataFrame."""
+        df = read_table(path)
+        if df.empty:
+            raise ValueError("Файл не містить даних")
+        return df
+
+    def suggest_mapping(self, key: str, df: pd.DataFrame) -> ColumnMapping:
+        """Повертає пропонований мапінг колонок."""
+        last = self.config.last_mappings.get(key, {})
+        mapping = detect_columns(df, last_mapping=last)
+        return mapping
+
+    def update_mapping_cache(self, key: str, mapping: ColumnMapping) -> None:
+        """Зберігає мапінг у конфіг для подальшого використання."""
+        self.config.last_mappings[key] = mapping.to_dict()
+        config_module.save_config(self.config, self.base_dir)
+
+    # --- Робота з даними ---
+    def set_user_price(self, path: Path, df: pd.DataFrame, mapping: ColumnMapping) -> None:
+        """Зберігає мій прайс."""
+        prepared = apply_mapping(df, mapping)
+        normalized = normalize_dataframe(prepared, self.config.film_map)
+        self.user_df = normalized
+        self.user_path = path
+        self.update_mapping_cache("user", mapping)
+        self._log_info(f"Завантажено мій прайс: {path} ({len(normalized)} рядків)")
+
+    def add_supplier(self, path: Path, df: pd.DataFrame, mapping: ColumnMapping) -> None:
+        """Додає прайс постачальника."""
+        prepared = apply_mapping(df, mapping)
+        normalized = normalize_dataframe(prepared, self.config.film_map)
+        supplier = SupplierData(path=path, dataframe=normalized, mapping=mapping)
+        self.suppliers.append(supplier)
+        cache_key = f"supplier::{path.suffix.lower()}"
+        self.update_mapping_cache(cache_key, mapping)
+        self._log_info(f"Додано постачальника: {path.name} ({len(normalized)} рядків)")
+
+    def clear_suppliers(self) -> None:
+        self.suppliers.clear()
+
+    # --- Матчинг ---
+    def run_matching(self, generate_canon_id: bool = False) -> Dict[str, pd.DataFrame]:
+        """Виконує процедуру матчінгу."""
+        if self.user_df is None:
+            raise ValueError("Спочатку завантажте мій прайс")
+        if not self.suppliers:
+            raise ValueError("Додайте хоча б один прайс постачальника")
+        supplier_payload: List[tuple[str, pd.DataFrame]] = []
+        for supplier in self.suppliers:
+            supplier_payload.append((supplier.source_name, supplier.dataframe))
+        results = match_user_vs_suppliers(self.user_df, supplier_payload, self.config)
+        if generate_canon_id:
+            for key, df in results.items():
+                if df.empty:
+                    continue
+                df["canon_id"] = df.apply(
+                    lambda row: hashid(
+                        str(row.get("brand_norm", "")),
+                        str(row.get("model_norm", "")),
+                        str(row.get("film_type_norm", "")),
+                    ),
+                    axis=1,
+                )
+        self.results = results
+        counts = {key: len(df) for key, df in results.items()}
+        self._log_info(f"Матчинг завершено: {counts}")
+        return results
+
+    # --- Сервісні ---
+    def stats_summary(self) -> str:
+        if not self.results:
+            return "Матчинг ще не виконувався"
+        exact = len(self.results.get("exact", []))
+        near = len(self.results.get("near", []))
+        unmatched = len(self.results.get("unmatched", []))
+        return f"Exact: {exact} | Near: {near} | Unmatched: {unmatched}"
+
+    def _log_info(self, message: str) -> None:
+        if self.logger:
+            self.logger.info(message)
+
+    def _log_error(self, message: str) -> None:
+        if self.logger:
+            self.logger.error(message)

--- a/matcher_app/matcher/exporters.py
+++ b/matcher_app/matcher/exporters.py
@@ -1,0 +1,72 @@
+"""Експорт результатів матчінгу у CSV."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Optional
+
+import pandas as pd
+
+CSV_PARAMS = {"index": False, "encoding": "utf-8-sig", "sep": ","}
+
+
+def export_csv(df: pd.DataFrame, path: Path | str, columns: Optional[Iterable[str]] = None) -> None:
+    """Зберігає DataFrame у CSV з utf-8-sig."""
+    target = Path(path)
+    if df.empty:
+        # Створюємо порожній файл з заголовком для прозорості.
+        if columns is None:
+            df.head(0).to_csv(target, **CSV_PARAMS)
+        else:
+            pd.DataFrame(columns=list(columns)).to_csv(target, **CSV_PARAMS)
+        return
+    export_df = df
+    if columns:
+        available = [col for col in columns if col in df.columns]
+        export_df = df[available]
+    export_df.to_csv(target, **CSV_PARAMS)
+
+
+def export_exact(df: pd.DataFrame, path: Path | str) -> None:
+    columns = [
+        "name",
+        "brand",
+        "model",
+        "film_type",
+        "sku",
+        "id",
+        "price",
+        "block_key",
+        "__source__",
+        "name_sup",
+        "brand_sup",
+        "model_sup",
+        "film_type_sup",
+        "price_sup",
+        "score",
+    ]
+    export_csv(df, path, columns)
+
+
+def export_near(df: pd.DataFrame, path: Path | str) -> None:
+    columns = [
+        "name",
+        "brand",
+        "model",
+        "film_type",
+        "price",
+        "block_key",
+        "score",
+        "auto_match",
+        "__source__",
+        "name_sup",
+        "brand_sup",
+        "model_sup",
+        "film_type_sup",
+        "price_sup",
+    ]
+    export_csv(df, path, columns)
+
+
+def export_unmatched(df: pd.DataFrame, path: Path | str) -> None:
+    columns = ["name", "brand", "model", "film_type", "sku", "id", "price", "block_key"]
+    export_csv(df, path, columns)

--- a/matcher_app/matcher/hashid.py
+++ b/matcher_app/matcher/hashid.py
@@ -1,0 +1,39 @@
+"""Генерація стабільних коротких ідентифікаторів."""
+from __future__ import annotations
+
+from hashlib import blake2b
+
+CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+_BASE = len(CROCKFORD)
+
+
+def to_crockford(number: int, length: int) -> str:
+    """Кодує число у Base32 Crockford фіксованої довжини."""
+    if number < 0:
+        raise ValueError("number має бути невід'ємним")
+    if length <= 0:
+        raise ValueError("length має бути додатнім")
+    if number == 0:
+        digits = [CROCKFORD[0]]
+    else:
+        digits = []
+        while number > 0:
+            number, remainder = divmod(number, _BASE)
+            digits.append(CROCKFORD[remainder])
+    while len(digits) < length:
+        digits.append(CROCKFORD[0])
+    encoded = "".join(reversed(digits))
+    if len(encoded) > length:
+        encoded = encoded[-length:]
+    return encoded
+
+
+def hashid(*parts: str, length: int = 12) -> str:
+    """Детермінований короткий ідентифікатор на базі BLAKE2b-80."""
+    if not parts:
+        raise ValueError("Потрібно передати хоча б один елемент")
+    length = max(6, min(20, length))
+    normalized = "|".join(part.strip().lower() for part in parts)
+    digest = blake2b(normalized.encode("utf-8"), digest_size=10).digest()
+    number = int.from_bytes(digest, "big")
+    return to_crockford(number, length)

--- a/matcher_app/matcher/io_utils.py
+++ b/matcher_app/matcher/io_utils.py
@@ -1,0 +1,126 @@
+"""Інструменти введення/виведення для MatcherApp."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+import pandas as pd
+
+from .models import ColumnMapping
+
+_REQUIRED_FIELDS = ("name", "brand", "model", "film_type")
+
+_COLUMN_ALIASES: Dict[str, Iterable[str]] = {
+    "name": [
+        "назва позиції",
+        "назва",
+        "title",
+        "name",
+        "productname",
+        "наименование",
+    ],
+    "brand": [
+        "виробник",
+        "бренд",
+        "brand",
+        "бренд пристрою",
+        "производитель",
+    ],
+    "model": [
+        "модель",
+        "model",
+        "модель ",
+        "модель устройства",
+        "device model",
+    ],
+    "film_type": [
+        "тип_плівки",
+        "тип плівки",
+        "film_type",
+        "серія чохла",
+        "тип",
+        "series",
+        "лінійка",
+    ],
+    "sku": [
+        "код_товару",
+        "sku",
+        "артикул",
+        "код товару",
+        "vendorcode",
+    ],
+    "product_id": [
+        "ідентифікатор_товару",
+        "id",
+        "ідентифікатор товару",
+    ],
+    "price": [
+        "ціна",
+        "price",
+        "цена",
+    ],
+}
+
+
+def _normalize_column_name(name: str) -> str:
+    return name.strip().lower().replace("\u00a0", " ")
+
+
+def read_table(path: Path) -> pd.DataFrame:
+    """Зчитує CSV/XLSX у DataFrame."""
+    if not path.exists():
+        raise FileNotFoundError(f"Файл не знайдено: {path}")
+    if path.suffix.lower() in {".csv", ".txt"}:
+        return pd.read_csv(path)
+    if path.suffix.lower() in {".xlsx", ".xls"}:
+        return pd.read_excel(path)
+    raise ValueError("Підтримуються лише CSV або XLSX")
+
+
+def detect_columns(df: pd.DataFrame, last_mapping: Optional[Dict[str, str]] = None) -> ColumnMapping:
+    """Пробує знайти відповідність колонок у DataFrame."""
+    mapping = ColumnMapping()
+    normalized = {_normalize_column_name(col): col for col in df.columns}
+    if last_mapping:
+        for field, column in last_mapping.items():
+            if column and column in df.columns:
+                setattr(mapping, field, column)
+    for field, aliases in _COLUMN_ALIASES.items():
+        if getattr(mapping, field):
+            continue
+        for alias in aliases:
+            alias_norm = _normalize_column_name(alias)
+            for candidate_norm, original in normalized.items():
+                if candidate_norm == alias_norm:
+                    setattr(mapping, field, original)
+                    break
+            if getattr(mapping, field):
+                break
+    return mapping
+
+
+def apply_mapping(df: pd.DataFrame, mapping: ColumnMapping) -> pd.DataFrame:
+    """Повертає DataFrame з уніфікованими колонками."""
+    missing = mapping.required_missing()
+    if missing:
+        raise ValueError(f"Вкажіть колонки для: {', '.join(missing)}")
+    rename_map = {
+        mapping.name: "name",
+        mapping.brand: "brand",
+        mapping.model: "model",
+        mapping.film_type: "film_type",
+    }
+    optional_fields = {
+        mapping.sku: "sku",
+        mapping.product_id: "id",
+        mapping.price: "price",
+    }
+    for src, dst in optional_fields.items():
+        if src:
+            rename_map[src] = dst
+    df = df.rename(columns=rename_map)
+    # Забезпечимо наявність опційних колонок
+    for optional in ("sku", "id", "price"):
+        if optional not in df.columns:
+            df[optional] = None
+    return df

--- a/matcher_app/matcher/logging_utils.py
+++ b/matcher_app/matcher/logging_utils.py
@@ -1,0 +1,30 @@
+"""Налаштування логування для MatcherApp."""
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Optional
+
+LOG_FILE_NAME = "matcher.log"
+
+
+def setup_logging(base_dir: Optional[Path] = None) -> logging.Logger:
+    """Створює та повертає логер застосунку."""
+    if base_dir is None:
+        base_dir = Path.cwd()
+    log_path = base_dir / LOG_FILE_NAME
+    logger = logging.getLogger("matcher_app")
+    if logger.handlers:
+        return logger
+    logger.setLevel(logging.INFO)
+    handler = RotatingFileHandler(log_path, maxBytes=1_000_000, backupCount=3, encoding="utf-8")
+    formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+    logger.propagate = False
+    logger.info("Логування ініціалізовано")
+    return logger

--- a/matcher_app/matcher/matching.py
+++ b/matcher_app/matcher/matching.py
@@ -1,0 +1,135 @@
+"""Модуль матчінгу між прайсами."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+import pandas as pd
+from rapidfuzz import fuzz
+
+from .config import Config
+
+
+def _to_float(value: object) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(str(value).replace(" ", "").replace(",", "."))
+    except (TypeError, ValueError):
+        return None
+
+
+def score_row(user_row: Dict[str, object], supplier_row: Dict[str, object], cfg: Config) -> float:
+    """Розраховує комбінований бал для рядка користувача та кандидата."""
+    score = 0.0
+    weights = cfg.weights
+    if user_row.get("brand_norm") and user_row.get("brand_norm") == supplier_row.get("brand_norm"):
+        score += weights.get("brand_exact", 0)
+    model_user = user_row.get("model_norm", "")
+    model_supplier = supplier_row.get("model_norm", "")
+    if model_user and model_supplier:
+        ratio = fuzz.token_set_ratio(model_user, model_supplier)
+        score += ratio / 100.0 * weights.get("model_fuzzy", 0)
+    film_user = user_row.get("film_type_norm", "")
+    film_supplier = supplier_row.get("film_type_norm", "")
+    if film_user and film_supplier and film_user == film_supplier:
+        score += weights.get("film_exact", 0)
+    name_user = user_row.get("name", "")
+    name_supplier = supplier_row.get("name", "")
+    if name_user and name_supplier:
+        partial = fuzz.partial_ratio(str(name_user), str(name_supplier))
+        score += partial / 100.0 * weights.get("name_fuzzy", 0)
+    price_user = _to_float(user_row.get("price"))
+    price_supplier = _to_float(supplier_row.get("price"))
+    if price_user and price_supplier and price_user > 0:
+        delta = abs(price_user - price_supplier) / price_user
+        if delta <= cfg.price_delta:
+            score += weights.get("price_proximity", 0)
+    return min(score, 100.0)
+
+
+@dataclass
+class MatchResult:
+    exact: pd.DataFrame
+    near: pd.DataFrame
+    unmatched: pd.DataFrame
+
+
+def match_user_vs_suppliers(
+    user_df: pd.DataFrame, suppliers: List[tuple[str, pd.DataFrame]], cfg: Config
+) -> Dict[str, pd.DataFrame]:
+    """Виконує strict та fuzzy матчинг між користувацьким прайсом та постачальниками."""
+    if user_df.empty:
+        raise ValueError("Мій прайс порожній")
+    if not suppliers:
+        raise ValueError("Додайте хоча б один прайс постачальника")
+    user_work = user_df.reset_index(drop=True).copy()
+    user_work["__user_idx"] = user_work.index
+
+    supplier_frames: List[pd.DataFrame] = []
+    for source_name, df in suppliers:
+        if df.empty:
+            continue
+        supplier_copy = df.copy()
+        supplier_copy["__source__"] = source_name
+        supplier_copy["__supplier_idx"] = supplier_copy.index
+        supplier_frames.append(supplier_copy)
+    if not supplier_frames:
+        raise ValueError("Усі прайси постачальників порожні")
+    suppliers_df = pd.concat(supplier_frames, ignore_index=True)
+    rename_map = {
+        col: f"{col}_sup"
+        for col in suppliers_df.columns
+        if col not in {"block_key", "__source__", "__supplier_idx"}
+    }
+    suppliers_df = suppliers_df.rename(columns=rename_map)
+
+    merged = user_work.merge(
+        suppliers_df,
+        on="block_key",
+        how="left",
+    )
+    exact_mask = merged["__source__"].notna()
+    exact_df = merged.loc[exact_mask].copy()
+    exact_df["score"] = 100.0
+
+    matched_user_ids = set(exact_df["__user_idx"].tolist())
+    unmatched_users = user_work[~user_work["__user_idx"].isin(matched_user_ids)].copy()
+
+    near_rows = []
+    unmatched_rows = []
+
+    suppliers_grouped = suppliers_df.groupby(["brand_norm_sup", "film_type_norm_sup"])
+
+    for _, user_row in unmatched_users.iterrows():
+        key = (user_row.get("brand_norm"), user_row.get("film_type_norm"))
+        try:
+            candidates = suppliers_grouped.get_group(key)
+        except KeyError:
+            unmatched_rows.append(user_row)
+            continue
+        best_score = 0.0
+        best_candidate = None
+        for _, supplier_row in candidates.iterrows():
+            score = score_row(user_row.to_dict(), supplier_row.to_dict(), cfg)
+            if score > best_score:
+                best_score = score
+                best_candidate = supplier_row
+        if best_candidate is None or best_score < cfg.near_threshold:
+            unmatched_rows.append(user_row)
+            continue
+        result_row = user_row.to_dict()
+        for column, value in best_candidate.items():
+            result_row[column] = value
+        result_row["score"] = best_score
+        result_row["auto_match"] = best_score >= cfg.exact_threshold
+        near_rows.append(result_row)
+
+    near_df = pd.DataFrame(near_rows)
+    unmatched_df = pd.DataFrame(unmatched_rows)
+
+    return {
+        "exact": exact_df,
+        "near": near_df,
+        "unmatched": unmatched_df,
+    }

--- a/matcher_app/matcher/models.py
+++ b/matcher_app/matcher/models.py
@@ -1,0 +1,66 @@
+"""Dataclass-моделі для MatcherApp."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional
+
+
+@dataclass
+class ColumnMapping:
+    """Відображення логічних полів на фактичні назви колонок."""
+
+    name: Optional[str] = None
+    brand: Optional[str] = None
+    model: Optional[str] = None
+    film_type: Optional[str] = None
+    sku: Optional[str] = None
+    product_id: Optional[str] = None
+    price: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        """Повертає словник для серіалізації."""
+        return {
+            "name": self.name,
+            "brand": self.brand,
+            "model": self.model,
+            "film_type": self.film_type,
+            "sku": self.sku,
+            "product_id": self.product_id,
+            "price": self.price,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Optional[str]]) -> "ColumnMapping":
+        """Створює ColumnMapping з dict."""
+        return cls(
+            name=data.get("name"),
+            brand=data.get("brand"),
+            model=data.get("model"),
+            film_type=data.get("film_type"),
+            sku=data.get("sku"),
+            product_id=data.get("product_id"),
+            price=data.get("price"),
+        )
+
+    def required_missing(self) -> list[str]:
+        """Повертає список відсутніх обов'язкових полів."""
+        missing = []
+        for attr in ("name", "brand", "model", "film_type"):
+            if getattr(self, attr) in (None, ""):
+                missing.append(attr)
+        return missing
+
+
+@dataclass
+class SupplierData:
+    """Прайс постачальника та його атрибути."""
+
+    path: Path
+    dataframe: "pd.DataFrame"
+    mapping: ColumnMapping = field(default_factory=ColumnMapping)
+
+    @property
+    def source_name(self) -> str:
+        """Назва джерела (файл)."""
+        return self.path.name

--- a/matcher_app/matcher/normalization.py
+++ b/matcher_app/matcher/normalization.py
@@ -1,0 +1,110 @@
+"""Модуль нормалізації полів для MatcherApp."""
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Dict
+
+import pandas as pd
+
+_ALLOWED_CHARS_RE = re.compile(r"[^a-z0-9+\.\- ]+")
+_MULTI_SPACE_RE = re.compile(r"\s+")
+
+_CYR_TO_LAT = {
+    "а": "a",
+    "б": "b",
+    "в": "v",
+    "г": "h",
+    "ґ": "g",
+    "д": "d",
+    "е": "e",
+    "є": "ie",
+    "ж": "zh",
+    "з": "z",
+    "и": "y",
+    "і": "i",
+    "ї": "i",
+    "й": "i",
+    "к": "k",
+    "л": "l",
+    "м": "m",
+    "н": "n",
+    "о": "o",
+    "п": "p",
+    "р": "r",
+    "с": "s",
+    "т": "t",
+    "у": "u",
+    "ф": "f",
+    "х": "h",
+    "ц": "ts",
+    "ч": "ch",
+    "ш": "sh",
+    "щ": "shch",
+    "ь": "",
+    "ю": "iu",
+    "я": "ia",
+    "ы": "y",
+    "э": "e",
+}
+
+
+def _simplify_text(value: str) -> str:
+    """Зводить рядок до базового латинського набору символів."""
+    value = value.strip().lower()
+    value = unicodedata.normalize("NFKD", value)
+    value = "".join(char for char in value if not unicodedata.combining(char))
+    converted = []
+    for char in value:
+        if char in _CYR_TO_LAT:
+            converted.append(_CYR_TO_LAT[char])
+        else:
+            converted.append(char)
+    simplified = "".join(converted)
+    simplified = _MULTI_SPACE_RE.sub(" ", simplified)
+    simplified = _ALLOWED_CHARS_RE.sub(" ", simplified)
+    return simplified.strip()
+
+
+def normalize_text(value: object) -> str:
+    """Повертає нормалізований текст для загальних полів."""
+    if value is None:
+        return ""
+    text = str(value)
+    if not text.strip():
+        return ""
+    return _simplify_text(text)
+
+
+def normalize_film_type(value: object, film_map: Dict[str, str]) -> str:
+    """Нормалізує тип плівки з урахуванням словника."""
+    base = normalize_text(value)
+    if not base:
+        return ""
+    key = base.replace("  ", " ")
+    mapped = film_map.get(key)
+    if mapped:
+        return mapped
+    return film_map.get(key.replace(" ", ""), base) or base
+
+
+def build_block_key(brand: str, model: str, film_type: str) -> str:
+    """Формує blocking-ключ."""
+    return " | ".join(part for part in (brand, model, film_type) if part)
+
+
+def normalize_dataframe(df: pd.DataFrame, film_map: Dict[str, str]) -> pd.DataFrame:
+    """Повертає копію DataFrame з нормалізованими колонками."""
+    required_columns = ["brand", "model", "film_type"]
+    for column in required_columns:
+        if column not in df.columns:
+            df[column] = ""
+    df = df.copy()
+    df["brand_norm"] = df["brand"].map(normalize_text)
+    df["model_norm"] = df["model"].map(normalize_text)
+    df["film_type_norm"] = df["film_type"].map(lambda val: normalize_film_type(val, film_map))
+    df["block_key"] = df.apply(
+        lambda row: build_block_key(row.get("brand_norm", ""), row.get("model_norm", ""), row.get("film_type_norm", "")),
+        axis=1,
+    )
+    return df

--- a/matcher_app/matcher/ui_app.py
+++ b/matcher_app/matcher/ui_app.py
@@ -1,0 +1,251 @@
+"""Графічний інтерфейс MatcherApp."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import customtkinter as ctk
+import pandas as pd
+from tkinter import Menu, filedialog, messagebox, ttk
+
+from .core import MatcherCore
+from .exporters import export_exact, export_near, export_unmatched
+from .logging_utils import setup_logging
+from .models import ColumnMapping
+
+
+_REQUIRED_FIELDS = {
+    "name": "Назва",
+    "brand": "Бренд",
+    "model": "Модель",
+    "film_type": "Тип плівки",
+}
+_OPTIONAL_FIELDS = {
+    "sku": "Артикул",
+    "product_id": "ID",
+    "price": "Ціна",
+}
+
+
+class MappingDialog(ctk.CTkToplevel):
+    """Діалог ручного мапінгу колонок."""
+
+    def __init__(self, master, columns: list[str], mapping: ColumnMapping):
+        super().__init__(master)
+        self.title("Налаштування колонок")
+        self.geometry("420x360")
+        self.resizable(False, False)
+        self.result: Optional[ColumnMapping] = None
+        self.columns = [""] + columns
+        self._inputs: dict[str, ctk.CTkOptionMenu] = {}
+        frame = ctk.CTkFrame(self)
+        frame.pack(fill="both", expand=True, padx=16, pady=16)
+        row = 0
+        for field, label_text in _REQUIRED_FIELDS.items():
+            ctk.CTkLabel(frame, text=f"{label_text} *").grid(row=row, column=0, sticky="w", pady=4)
+            option = ctk.CTkOptionMenu(frame, values=self.columns)
+            option.set(getattr(mapping, field) or "")
+            option.grid(row=row, column=1, sticky="ew", pady=4)
+            self._inputs[field] = option
+            row += 1
+        for field, label_text in _OPTIONAL_FIELDS.items():
+            ctk.CTkLabel(frame, text=label_text).grid(row=row, column=0, sticky="w", pady=4)
+            option = ctk.CTkOptionMenu(frame, values=self.columns)
+            option.set(getattr(mapping, field, "") or "")
+            option.grid(row=row, column=1, sticky="ew", pady=4)
+            self._inputs[field] = option
+            row += 1
+        frame.columnconfigure(1, weight=1)
+        btn_frame = ctk.CTkFrame(self)
+        btn_frame.pack(fill="x", padx=16, pady=(0, 16))
+        ctk.CTkButton(btn_frame, text="Скасувати", command=self._on_cancel).pack(side="right", padx=4)
+        ctk.CTkButton(btn_frame, text="Зберегти", command=self._on_save).pack(side="right", padx=4)
+        self.grab_set()
+        self.focus_set()
+
+    def _on_save(self) -> None:
+        mapping = ColumnMapping()
+        for field in _REQUIRED_FIELDS:
+            value = self._inputs[field].get() or None
+            setattr(mapping, field, value)
+        mapping.sku = self._inputs["sku"].get() or None
+        mapping.product_id = self._inputs["product_id"].get() or None
+        mapping.price = self._inputs["price"].get() or None
+        if mapping.required_missing():
+            messagebox.showerror("Помилка", "Заповніть усі обов'язкові поля")
+            return
+        self.result = mapping
+        self.destroy()
+
+    def _on_cancel(self) -> None:
+        self.result = None
+        self.destroy()
+
+
+class MatcherAppUI:
+    """Основний клас GUI."""
+
+    def __init__(self) -> None:
+        ctk.set_appearance_mode("light")
+        ctk.set_default_color_theme("blue")
+        self.root = ctk.CTk()
+        self.root.title("Matcher App — MVP")
+        self.root.geometry("980x640")
+        self.core = MatcherCore()
+        self.logger = setup_logging(Path.cwd())
+        self.core.attach_logger(self.logger)
+        self.generate_canon = ctk.BooleanVar(value=False)
+        self._build_menu()
+        self._build_layout()
+        self.results: Optional[dict[str, pd.DataFrame]] = None
+
+    # --- UI складання ---
+    def _build_menu(self) -> None:
+        menu_bar = Menu(self.root)
+        file_menu = Menu(menu_bar, tearoff=False)
+        file_menu.add_command(label="Завантажити мій прайс…", command=self.on_load_user)
+        file_menu.add_command(label="Додати прайс постачальника…", command=self.on_add_supplier)
+        file_menu.add_separator()
+        file_menu.add_command(label="Вихід", command=self.root.destroy)
+        menu_bar.add_cascade(label="Файл", menu=file_menu)
+
+        match_menu = Menu(menu_bar, tearoff=False)
+        match_menu.add_checkbutton(label="Генерувати canon_id", variable=self.generate_canon)
+        match_menu.add_command(label="Запустити матчинг", command=self.on_run_matching)
+        menu_bar.add_cascade(label="Матчинг", menu=match_menu)
+
+        export_menu = Menu(menu_bar, tearoff=False)
+        export_menu.add_command(label="Експорт Exact…", command=lambda: self.on_export("exact"))
+        export_menu.add_command(label="Експорт Near…", command=lambda: self.on_export("near"))
+        export_menu.add_command(label="Експорт Unmatched…", command=lambda: self.on_export("unmatched"))
+        menu_bar.add_cascade(label="Експорт", menu=export_menu)
+
+        self.root.configure(menu=menu_bar)
+
+    def _build_layout(self) -> None:
+        frame = ctk.CTkFrame(self.root)
+        frame.pack(fill="both", expand=True, padx=12, pady=12)
+        columns = ("source", "rows", "note")
+        self.tree = ttk.Treeview(frame, columns=columns, show="headings", height=12)
+        self.tree.heading("source", text="Джерело")
+        self.tree.heading("rows", text="Рядків")
+        self.tree.heading("note", text="Примітка")
+        self.tree.column("source", width=400)
+        self.tree.column("rows", width=80, anchor="center")
+        self.tree.column("note", width=320)
+        self.tree.pack(fill="both", expand=True)
+        self.status_label = ctk.CTkLabel(self.root, text="Готово")
+        self.status_label.pack(fill="x", padx=12, pady=(0, 12))
+        self.tree_data: dict[str, str] = {}
+        self._refresh_tree()
+
+    def _refresh_tree(self) -> None:
+        for item in self.tree.get_children():
+            self.tree.delete(item)
+        user_note = self.core.user_path.name if self.core.user_path else "Не завантажено"
+        user_rows = len(self.core.user_df) if self.core.user_df is not None else 0
+        self.tree.insert("", "end", values=("Мій прайс", user_rows, user_note))
+        for supplier in self.core.suppliers:
+            note = supplier.path.name
+            rows = len(supplier.dataframe)
+            self.tree.insert("", "end", values=(f"Постачальник: {note}", rows, ""))
+
+    # --- Дії ---
+    def on_load_user(self) -> None:
+        path_str = filedialog.askopenfilename(
+            title="Оберіть файл мого прайсу",
+            filetypes=[("Таблиці", "*.csv *.xlsx"), ("CSV", "*.csv"), ("Excel", "*.xlsx")],
+        )
+        if not path_str:
+            return
+        path = Path(path_str)
+        try:
+            df = self.core.load_dataframe(path)
+        except Exception as exc:
+            messagebox.showerror("Помилка", str(exc))
+            return
+        mapping = self.core.suggest_mapping("user", df)
+        if mapping.required_missing():
+            dialog = MappingDialog(self.root, list(df.columns), mapping)
+            self.root.wait_window(dialog)
+            if dialog.result is None:
+                return
+            mapping = dialog.result
+        try:
+            self.core.set_user_price(path, df, mapping)
+            self.status_label.configure(text=f"Мій прайс: {len(self.core.user_df)} рядків")
+        except Exception as exc:
+            messagebox.showerror("Помилка", str(exc))
+        self._refresh_tree()
+
+    def on_add_supplier(self) -> None:
+        path_str = filedialog.askopenfilename(
+            title="Оберіть файл постачальника",
+            filetypes=[("Таблиці", "*.csv *.xlsx"), ("CSV", "*.csv"), ("Excel", "*.xlsx")],
+        )
+        if not path_str:
+            return
+        path = Path(path_str)
+        try:
+            df = self.core.load_dataframe(path)
+        except Exception as exc:
+            messagebox.showerror("Помилка", str(exc))
+            return
+        cache_key = f"supplier::{path.suffix.lower()}"
+        mapping = self.core.suggest_mapping(cache_key, df)
+        if mapping.required_missing():
+            dialog = MappingDialog(self.root, list(df.columns), mapping)
+            self.root.wait_window(dialog)
+            if dialog.result is None:
+                return
+            mapping = dialog.result
+        try:
+            self.core.add_supplier(path, df, mapping)
+            self.status_label.configure(text=f"Додано постачальника {path.name}")
+        except Exception as exc:
+            messagebox.showerror("Помилка", str(exc))
+        self._refresh_tree()
+
+    def on_run_matching(self) -> None:
+        try:
+            results = self.core.run_matching(self.generate_canon.get())
+        except Exception as exc:
+            messagebox.showerror("Помилка", str(exc))
+            return
+        self.results = results
+        self.status_label.configure(text=self.core.stats_summary())
+
+    def on_export(self, key: str) -> None:
+        if not self.results or key not in self.results:
+            messagebox.showwarning("Увага", "Спочатку виконайте матчинг")
+            return
+        df = self.results[key]
+        if df is None:
+            messagebox.showwarning("Увага", "Немає даних для експорту")
+            return
+        default_name = f"{key}.csv"
+        path_str = filedialog.asksaveasfilename(
+            title="Збереження CSV",
+            defaultextension=".csv",
+            initialfile=default_name,
+            filetypes=[("CSV", "*.csv")],
+        )
+        if not path_str:
+            return
+        path = Path(path_str)
+        try:
+            if key == "exact":
+                export_exact(df, path)
+            elif key == "near":
+                export_near(df, path)
+            else:
+                export_unmatched(df, path)
+            self.status_label.configure(text=f"Експортовано {key} у {path.name}")
+        except Exception as exc:
+            messagebox.showerror("Помилка", str(exc))
+
+    def run(self) -> None:
+        self.root.mainloop()
+
+
+__all__ = ["MatcherAppUI"]

--- a/matcher_app/requirements.txt
+++ b/matcher_app/requirements.txt
@@ -1,0 +1,5 @@
+customtkinter==5.2.2
+pandas==2.2.2
+openpyxl==3.1.5
+rapidfuzz==3.9.1
+pyinstaller==6.6.0

--- a/matcher_app/run.bat
+++ b/matcher_app/run.bat
@@ -1,0 +1,9 @@
+@echo off
+SETLOCAL
+IF NOT EXIST .venv (
+    echo Створіть середовище .venv перед запуском.
+    exit /b 1
+)
+CALL .venv\Scripts\activate.bat
+python main.py
+ENDLOCAL


### PR DESCRIPTION
## Summary
- add MatcherApp package with configuration, normalization, fuzzy matching, and export utilities
- implement CustomTkinter GUI for loading price lists, mapping columns, running matching, and exporting results
- provide documentation, dependency list, and Windows helper scripts for running and building the app

## Testing
- python -m compileall matcher_app

------
https://chatgpt.com/codex/tasks/task_e_68d59da113bc8325ad7b5b1b33bf20de